### PR TITLE
Add timezone to the event itself

### DIFF
--- a/src/pages/api/prayer-times.ics.ts
+++ b/src/pages/api/prayer-times.ics.ts
@@ -31,6 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             .add(duration ? +duration : 25, 'minute')
             .toDate(),
           summary: name,
+          timezone: day.meta.timezone,
         });
         event.createAlarm({
           type: ICalAlarmType.audio,


### PR DESCRIPTION
This little change adds the default timezone to the ICS event.
In fact, the events are not forced UTC but they have the field empty, this seems to puzzle some ICS clients which end up assigning the _current_ zone instead.

Fixes: https://github.com/AhmedElywa/prayCalendar/issues/2