### PR TITLE
Allow no alarm

### DIFF
--- a/src/pages/api/prayer-times.ics.ts
+++ b/src/pages/api/prayer-times.ics.ts
@@ -32,7 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             .toDate(),
           summary: name,
         });
-        if (+alarm !== 0) {
+        if (alarm && +alarm > 0) {
             event.createAlarm({
                 type: ICalAlarmType.audio,
                 triggerBefore: (alarm ? +alarm : 15) * 60,

--- a/src/pages/api/prayer-times.ics.ts
+++ b/src/pages/api/prayer-times.ics.ts
@@ -32,7 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             .toDate(),
           summary: name,
         });
-        if (alarm != 0) {
+        if (+alarm !== 0) {
             event.createAlarm({
                 type: ICalAlarmType.audio,
                 triggerBefore: (alarm ? +alarm : 15) * 60,

--- a/src/pages/api/prayer-times.ics.ts
+++ b/src/pages/api/prayer-times.ics.ts
@@ -32,10 +32,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             .toDate(),
           summary: name,
         });
-        event.createAlarm({
-          type: ICalAlarmType.audio,
-          triggerBefore: (alarm ? +alarm : 15) * 60,
-        });
+        if (alarm != 0) {
+            event.createAlarm({
+                type: ICalAlarmType.audio,
+                triggerBefore: (alarm ? +alarm : 15) * 60,
+            });
+        }
       }
     }
     res.setHeader('Content-Type', 'text/calendar');

--- a/src/pages/api/prayer-times.ics.ts
+++ b/src/pages/api/prayer-times.ics.ts
@@ -35,7 +35,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (alarm && +alarm > 0) {
             event.createAlarm({
                 type: ICalAlarmType.audio,
-                triggerBefore: (alarm ? +alarm : 15) * 60,
+                triggerBefore: +alarm * 60,
             });
         }
       }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -66,6 +66,7 @@ const Index: React.FC = () => {
             onChange={(event) => setAlarm(event.target.value)}
             className="rounded-md border border-sky-400 p-2 dark:bg-gray-800 dark:text-gray-100"
           >
+            <option value="0">No alarm</option>
             <option value="5">5 minutes</option>
             <option value="10">10 minutes</option>
             <option value="15">15 minutes</option>


### PR DESCRIPTION
This PR adds the possibility to create events without alarms, in case the user just wants them visible in the calendar.
If the alarm is set to 0, we won't add it to the event.