### PR TITLE
Fix duration 0 handling

### DIFF
--- a/src/__tests__/pages/api/prayer-times.ics.test.ts
+++ b/src/__tests__/pages/api/prayer-times.ics.test.ts
@@ -26,10 +26,11 @@ jest.mock('ical-generator', () => {
   };
 });
 
+const addMock = jest.fn().mockReturnThis();
 jest.mock('moment/moment', () => {
   const momentMock = jest.fn(() => ({
     toDate: jest.fn().mockReturnValue(new Date()),
-    add: jest.fn().mockReturnThis(),
+    add: addMock,
     isBefore: jest.fn().mockReturnValue(false),
   }));
 
@@ -104,6 +105,14 @@ describe('Prayer Times API', () => {
     await handler(req as NextApiRequest, res as NextApiResponse);
     expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/calendar');
     expect(res.send).toHaveBeenCalledWith('calendar-content');
+  });
+
+  it('respects zero duration in query', async () => {
+    if (req.query) {
+      req.query.duration = '0';
+    }
+    await handler(req as NextApiRequest, res as NextApiResponse);
+    expect(addMock).toHaveBeenCalledWith(0, 'minute');
   });
 
   it('filters events based on events query parameter', async () => {

--- a/src/pages/api/prayer-times.ics.ts
+++ b/src/pages/api/prayer-times.ics.ts
@@ -32,7 +32,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       for (const [name, time] of Object.entries(day.timings)) {
         if (!allowedEvents.includes(name)) continue;
         const startDate = moment(`${day.date.gregorian.date} ${time}`, 'DD-MM-YYYY HH:mm').toDate();
-        const defaultDuration = name === 'Sunrise' ? 10 : name === 'Midnight' ? 1 : duration ? +duration : 25;
+        const defaultDuration =
+          name === 'Sunrise'
+            ? 10
+            : name === 'Midnight'
+            ? 1
+            : duration !== undefined
+            ? +duration
+            : 25;
         const event = calendar.createEvent({
           start: startDate,
           end: moment(startDate).add(defaultDuration, 'minute').toDate(),


### PR DESCRIPTION
## Summary
- fix handling of `duration` parameter in API
- ensure zero duration does not fall back to default
- test zero-duration behaviour in prayer times API

## Testing
- `pnpm exec jest --version` *(fails: Command "jest" not found)*