### PR TITLE
Add multi-alarm checkbox support

### DIFF
--- a/src/__tests__/pages/api/prayer-times.ics.test.ts
+++ b/src/__tests__/pages/api/prayer-times.ics.test.ts
@@ -26,19 +26,17 @@ jest.mock('ical-generator', () => {
   };
 });
 
-const addMock = jest.fn().mockReturnThis();
 jest.mock('moment/moment', () => {
+  const addMock = jest.fn().mockReturnThis();
   const momentMock = jest.fn(() => ({
     toDate: jest.fn().mockReturnValue(new Date()),
     add: addMock,
     isBefore: jest.fn().mockReturnValue(false),
   }));
-
-  // Add tz function to the mock
   (momentMock as any).tz = jest.fn().mockReturnThis();
-
-  return momentMock;
+  return { __esModule: true, default: momentMock, addMock };
 });
+import { addMock } from 'moment/moment';
 
 describe('Prayer Times API', () => {
   let req: Partial<NextApiRequest>;

--- a/src/__tests__/pages/index.test.tsx
+++ b/src/__tests__/pages/index.test.tsx
@@ -48,44 +48,40 @@ describe('Index component', () => {
     expect(copyText.textContent).toContain('method=0');
   });
 
-  it('updates alarm when select changes', () => {
+  it('updates alarm when checkboxes change', () => {
     render(<Index />);
-    const select = screen.getByLabelText(/Alarm/i);
-    fireEvent.change(select, { target: { value: '10' } });
+    const tenBefore = screen.getByLabelText('10 minutes before');
+    fireEvent.click(tenBefore);
 
-    const copyText = screen.getByTestId('copy-text');
+    let copyText = screen.getByTestId('copy-text');
+    expect(copyText.textContent).toContain('alarm=5,10');
+
+    fireEvent.click(screen.getByLabelText('5 minutes before'));
+    copyText = screen.getByTestId('copy-text');
     expect(copyText.textContent).toContain('alarm=10');
   });
 
   it('toggles prayer events when checkboxes are clicked', () => {
     render(<Index />);
 
-    // Get all checkboxes
-    const checkboxes = screen.getAllByRole('checkbox');
-    expect(checkboxes.length).toBe(7); // There should be 7 prayer events
+    const eventNames = ['Fajr', 'Sunrise', 'Dhuhr', 'Asr', 'Maghrib', 'Isha', 'Midnight'];
+    const checkboxes = eventNames.map((name) => screen.getByLabelText(name));
+    expect(checkboxes.length).toBe(7);
 
-    // By default all should be checked
     checkboxes.forEach((checkbox) => {
       expect(checkbox).toBeChecked();
     });
 
-    // Uncheck the first prayer event (Fajr)
     fireEvent.click(checkboxes[0]);
-
-    // Now the link should include the events parameter with the remaining events
-    const copyText = screen.getByTestId('copy-text');
+    let copyText = screen.getByTestId('copy-text');
     expect(copyText.textContent).toContain('events=1,2,3,4,5,6');
 
-    // Uncheck the second prayer event (Sunrise)
     fireEvent.click(checkboxes[1]);
+    copyText = screen.getByTestId('copy-text');
+    expect(copyText.textContent).toContain('events=2,3,4,5,6');
 
-    // Now the link should include just the remaining events
-    expect(screen.getByTestId('copy-text').textContent).toContain('events=2,3,4,5,6');
-
-    // Check the first one again
     fireEvent.click(checkboxes[0]);
-
-    // Now the link should include the updated events
-    expect(screen.getByTestId('copy-text').textContent).toContain('events=0,2,3,4,5,6');
+    copyText = screen.getByTestId('copy-text');
+    expect(copyText.textContent).toContain('events=0,2,3,4,5,6');
   });
 });

--- a/src/components
+++ b/src/components
@@ -1,1 +1,0 @@
-Components

--- a/src/components
+++ b/src/components
@@ -1,0 +1,1 @@
+Components

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,17 @@ import ThemeMenu from 'Components/Theme';
 const Index: React.FC = () => {
   const [address, setAddress] = React.useState('');
   const [method, setMethod] = React.useState('5');
-  const [alarm, setAlarm] = React.useState('5');
+  const alarmOptions = [
+    { value: 5, label: '5 minutes before' },
+    { value: 10, label: '10 minutes before' },
+    { value: 15, label: '15 minutes before' },
+    { value: 30, label: '30 minutes before' },
+    { value: 0, label: 'In the time' },
+    { value: -5, label: '5 minutes after' },
+    { value: -10, label: '10 minutes after' },
+  ];
+  const alarmOrder = alarmOptions.map((o) => o.value);
+  const [alarms, setAlarms] = React.useState<number[]>([5]);
   const [duration, setDuration] = React.useState(25);
 
   const allEvents = ['Fajr', 'Sunrise', 'Dhuhr', 'Asr', 'Maghrib', 'Isha', 'Midnight'];
@@ -18,11 +28,20 @@ const Index: React.FC = () => {
     );
   };
 
+  const handleAlarmToggle = (value: number) => {
+    setAlarms((prev) => {
+      const exists = prev.includes(value);
+      const updated = exists ? prev.filter((a) => a !== value) : [...prev, value];
+      return updated.sort((a, b) => alarmOrder.indexOf(a) - alarmOrder.indexOf(b));
+    });
+  };
+
   const eventsParam = selectedEvents.length === allEvents.length ? '' : `&events=${selectedEvents.join(',')}`;
+  const alarmParam = alarms.length ? `&alarm=${alarms.join(',')}` : '';
 
   const link = `https://pray.ahmedelywa.com/api/prayer-times.ics?address=${encodeURIComponent(
     address,
-  )}&method=${method}&alarm=${alarm}&duration=${duration}${eventsParam}`;
+  )}&method=${method}${alarmParam}&duration=${duration}${eventsParam}`;
 
   return (
     <div className="mx-auto mb-6 flex min-h-screen max-w-screen-lg flex-col space-y-8 bg-gray-50 px-4 text-gray-900 selection:bg-gray-800 selection:text-gray-100 dark:bg-zinc-800 dark:text-gray-100 dark:selection:bg-gray-100 dark:selection:text-gray-900">
@@ -73,20 +92,6 @@ const Index: React.FC = () => {
       </label>
       <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
         <label className="space-2-8 flex flex-col font-medium">
-          Alarm (minutes before)
-          <select
-            defaultValue={alarm}
-            onChange={(event) => setAlarm(event.target.value)}
-            className="rounded-md border border-sky-400 p-2 dark:bg-gray-800 dark:text-gray-100"
-          >
-            <option value="0">No alarm</option>
-            <option value="5">5 minutes</option>
-            <option value="10">10 minutes</option>
-            <option value="15">15 minutes</option>
-            <option value="30">30 minutes</option>
-          </select>
-        </label>
-        <label className="space-2-8 flex flex-col font-medium">
           Duration (minutes)
           <input
             id="duration"
@@ -97,6 +102,23 @@ const Index: React.FC = () => {
             onChange={(event) => setDuration(+event.target.value)}
           />
         </label>
+      </div>
+
+      <div className="space-y-2">
+        <div className="font-medium">Select Alarms</div>
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          {alarmOptions.map((option) => (
+            <label key={option.value} className="flex cursor-pointer items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={alarms.includes(option.value)}
+                onChange={() => handleAlarmToggle(option.value)}
+                className="h-4 w-4"
+              />
+              <span>{option.label}</span>
+            </label>
+          ))}
+        </div>
       </div>
 
       <div className="space-y-2">


### PR DESCRIPTION
## Summary
- allow multiple alarm values on the frontend
- move alarm selector below duration input
- generate `alarm` query param from selected checkboxes
- support multiple alarm triggers in API
- fix tests to handle new alarm UI
- add symlink for components so jest works

## Testing
- `npm test --silent`