### PR TITLE
Add PWA support and prayer app page

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -15,5 +15,7 @@
     ],
     "theme_color": "#FFFFFF",
     "background_color": "#FFFFFF",
-    "display": "standalone"
+    "display": "standalone",
+    "start_url": "/pwa",
+    "scope": "/"
  }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'pray-calendar-v1';
+const STATIC_ASSETS = ['/', '/pwa', '/favicon.ico'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)));
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.map((key) => (key !== CACHE_NAME ? caches.delete(key) : undefined)))),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      const fetchPromise = fetch(event.request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(() => cached);
+      return cached || fetchPromise;
+    }),
+  );
+});

--- a/src/Components/ServiceWorkerRegister.tsx
+++ b/src/Components/ServiceWorkerRegister.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    }
+  }, []);
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Analytics } from '@vercel/analytics/next';
 import '../styles/globals.css';
+import ServiceWorkerRegister from '../Components/ServiceWorkerRegister';
 
 export const metadata = {
   metadataBase: new URL('https://pray.ahmedelywa.com'),
@@ -53,6 +54,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body style={{ fontFamily: `'Nunito', sans-serif` }} className="dark:bg-zinc-800">
         {children}
+        <ServiceWorkerRegister />
         <Analytics />
       </body>
     </html>

--- a/src/app/pwa/page.tsx
+++ b/src/app/pwa/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+import React from 'react';
+import Navigation from '../../Components/Navigation';
+import LocationInputs from '../../Components/LocationInputs';
+import PrayerPreview from '../../Components/PrayerPreview';
+import { useLanguage, useLocationFields, useTimingsPreview } from '../../hooks';
+import { translations } from '../../constants/translations';
+
+export default function PrayApp() {
+  const browserLang = typeof navigator !== 'undefined' && navigator.language.startsWith('ar') ? 'ar' : 'en';
+  const { lang, setLang } = useLanguage(browserLang);
+
+  const locationFields = useLocationFields();
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  React.useEffect(() => {
+    const saved = localStorage.getItem('pwaLocation');
+    if (saved) {
+      try {
+        const data = JSON.parse(saved);
+        if (data.inputMode === 'address') {
+          locationFields.setInputMode('address');
+          locationFields.setAddress(data.address || '');
+        } else {
+          locationFields.setInputMode('coords');
+          locationFields.setLatitude(data.latitude || '');
+          locationFields.setLongitude(data.longitude || '');
+        }
+        setCollapsed(true);
+      } catch {}
+    }
+  }, []);
+
+  const handleSave = () => {
+    const { inputMode, address, latitude, longitude } = locationFields;
+    localStorage.setItem('pwaLocation', JSON.stringify({ inputMode, address, latitude, longitude }));
+    setCollapsed(true);
+  };
+
+  const {
+    loading: loadingNext,
+    nextPrayer,
+    todayTimings,
+  } = useTimingsPreview({
+    inputMode: locationFields.inputMode,
+    address: locationFields.address,
+    latitude: locationFields.latitude,
+    longitude: locationFields.longitude,
+    method: '5',
+    lang,
+  });
+
+  return (
+    <main className="min-h-screen bg-gray-50 dark:bg-zinc-800">
+      <Navigation lang={lang} setLang={setLang} />
+      <div className="mx-auto max-w-screen-sm space-y-6 px-4 py-8">
+        {!collapsed && (
+          <div className="space-y-4">
+            <LocationInputs lang={lang} {...locationFields} />
+            <button
+              type="button"
+              onClick={handleSave}
+              className="rounded-md bg-sky-500 px-4 py-2 text-sm font-medium text-white"
+            >
+              {translations[lang].saveLocation || 'Save location'}
+            </button>
+          </div>
+        )}
+        {collapsed && (
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => setCollapsed(false)}
+              className="text-sm text-sky-600 dark:text-sky-400"
+            >
+              {translations[lang].changeLocation || 'Change location'}
+            </button>
+          </div>
+        )}
+        <PrayerPreview lang={lang} loadingNext={loadingNext} nextPrayer={nextPrayer} todayTimings={todayTimings} />
+      </div>
+    </main>
+  );
+}

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -51,6 +51,8 @@ export const translations = {
     inLabel: 'in',
     loadingNext: 'Loading next prayer…',
     eventsToday: "Today's prayer times",
+    saveLocation: 'Save location',
+    changeLocation: 'Change location',
   },
   ar: {
     title: 'إنشاء رابط اشتراك تقويم الصلاة',
@@ -104,5 +106,7 @@ export const translations = {
     inLabel: 'بعد',
     loadingNext: 'جارٍ تحميل الصلاة التالية…',
     eventsToday: 'مواقيت صلاة اليوم',
+    saveLocation: 'احفظ الموقع',
+    changeLocation: 'تغيير الموقع',
   },
 };


### PR DESCRIPTION
## Summary
- add simple service worker
- register service worker in layout
- make new `/pwa` page with location selector and prayer preview
- remember location in localStorage
- update translations
- update PWA manifest with start URL

## Testing
- `pnpm test`