### PR TITLE
refactor: use context directly

### DIFF
--- a/src/Components/AdvancedOptions.tsx
+++ b/src/Components/AdvancedOptions.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { translations } from '../constants/translations';
 import { alarmOptionsData } from '../constants/prayerData';
-import type { Lang } from '../hooks/useLanguage';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
+import { useAppContext } from '../contexts/AppContext';
 
 interface AdvancedOptionsProps {
-  lang: Lang;
   showAdvanced: boolean;
   setShowAdvanced: (show: boolean) => void;
   alarms: number[];
@@ -16,7 +15,6 @@ interface AdvancedOptionsProps {
 }
 
 export default function AdvancedOptions({
-  lang,
   showAdvanced,
   setShowAdvanced,
   alarms,
@@ -25,6 +23,7 @@ export default function AdvancedOptions({
   selectedEvents,
   handleEventToggle,
 }: AdvancedOptionsProps) {
+  const { lang } = useAppContext();
   return (
     <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-zinc-900">
       <button

--- a/src/Components/Footer.tsx
+++ b/src/Components/Footer.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import Link from 'next/link';
 import { translations } from '../constants/translations';
-import type { Lang } from '../hooks/useLanguage';
+import { useAppContext } from '../contexts/AppContext';
 
-interface FooterProps {
-  lang: Lang;
-}
-
-export default function Footer({ lang }: FooterProps) {
+export default function Footer() {
+  const { lang } = useAppContext();
   return (
     <footer className="border-t border-gray-200 bg-white py-4 dark:border-gray-700 dark:bg-zinc-900">
       <div className="mx-auto flex max-w-screen-lg items-center justify-center gap-6 px-4">

--- a/src/Components/InstructionsSection.tsx
+++ b/src/Components/InstructionsSection.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { translations } from '../constants/translations';
-import type { Lang } from '../hooks/useLanguage';
 import { InformationCircleIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
+import { useAppContext } from '../contexts/AppContext';
 
-interface InstructionsSectionProps {
-  lang: Lang;
-}
-
-export default function InstructionsSection({ lang }: InstructionsSectionProps) {
+export default function InstructionsSection() {
+  const { lang } = useAppContext();
   return (
     <div className="space-y-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-zinc-900">
       {/* Hint about editing */}

--- a/src/Components/LocationInputs.tsx
+++ b/src/Components/LocationInputs.tsx
@@ -1,36 +1,22 @@
 import React from 'react';
 import { translations } from '../constants/translations';
-import type { Lang } from '../hooks/useLanguage';
-import type { InputMode } from '../hooks/useLocationFields';
 import { MapPinIcon } from '@heroicons/react/24/outline';
+import { useAppContext } from '../contexts/AppContext';
 
-interface LocationInputsProps {
-  lang: Lang;
-  inputMode: InputMode;
-  setInputMode: (mode: InputMode) => void;
-  address: string;
-  setAddress: (address: string) => void;
-  latitude: number | '';
-  setLatitude: (lat: number | '') => void;
-  longitude: number | '';
-  setLongitude: (lon: number | '') => void;
-  locating: boolean;
-  handleUseLocation: () => void;
-}
-
-export default function LocationInputs({
-  lang,
-  inputMode,
-  setInputMode,
-  address,
-  setAddress,
-  latitude,
-  setLatitude,
-  longitude,
-  setLongitude,
-  locating,
-  handleUseLocation,
-}: LocationInputsProps) {
+export default function LocationInputs() {
+  const { lang, locationFields } = useAppContext();
+  const {
+    inputMode,
+    setInputMode,
+    address,
+    setAddress,
+    latitude,
+    setLatitude,
+    longitude,
+    setLongitude,
+    locating,
+    handleUseLocation,
+  } = locationFields;
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-zinc-900">
       {/* mode toggle */}

--- a/src/Components/MethodAndSettings.tsx
+++ b/src/Components/MethodAndSettings.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { translations } from '../constants/translations';
-import type { Lang } from '../hooks/useLanguage';
 import { CalendarDaysIcon, ClockIcon } from '@heroicons/react/24/outline';
 import { MethodSelectFields } from './MethodSelect';
+import { useAppContext } from '../contexts/AppContext';
 
 interface MethodAndSettingsProps {
-  lang: Lang;
   method: string;
   setMethod: (method: string) => void;
   duration: number;
@@ -15,7 +14,6 @@ interface MethodAndSettingsProps {
 }
 
 export default function MethodAndSettings({
-  lang,
   method,
   setMethod,
   duration,
@@ -23,12 +21,13 @@ export default function MethodAndSettings({
   months,
   setMonths,
 }: MethodAndSettingsProps) {
+  const { lang } = useAppContext();
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-zinc-900">
       <div className="space-y-6">
         {/* method selection */}
         <div>
-          <MethodSelectFields lang={lang} method={method} setMethod={setMethod} />
+          <MethodSelectFields method={method} setMethod={setMethod} />
         </div>
 
         {/* duration and months */}

--- a/src/Components/MethodSelect.tsx
+++ b/src/Components/MethodSelect.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { AdjustmentsHorizontalIcon } from '@heroicons/react/24/outline';
 import { translations } from '../constants/translations';
-import type { Lang } from '../hooks/useLanguage';
 import defaultMethod from './defaultMethod';
+import { useAppContext } from '../contexts/AppContext';
 
 export interface MethodSelectProps {
-  lang: Lang;
   method: string;
   setMethod: (method: string) => void;
 }
 
-export function MethodSelectFields({ lang, method, setMethod }: MethodSelectProps) {
+export function MethodSelectFields({ method, setMethod }: MethodSelectProps) {
+  const { lang } = useAppContext();
   return (
     <>
       <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">

--- a/src/Components/Navigation.tsx
+++ b/src/Components/Navigation.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import ThemeMenu from './Theme';
 import { translations } from '../constants/translations';
-import type { Lang } from '../hooks/useLanguage';
 import { GlobeAltIcon, CodeBracketIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import { useAppContext } from '../contexts/AppContext';
+import type { Lang } from '../hooks/useLanguage';
 
-interface NavigationProps {
-  lang: Lang;
-  setLang: (lang: Lang) => void;
-}
-
-export default function Navigation({ lang, setLang }: NavigationProps) {
+export default function Navigation() {
+  const { lang, setLang } = useAppContext();
   return (
     <nav className="relative z-10 border-b border-gray-200 bg-white py-4 shadow-sm dark:border-gray-700 dark:bg-zinc-900 print:hidden">
       <div className="mx-auto max-w-screen-lg px-4">

--- a/src/Components/PageLayout.tsx
+++ b/src/Components/PageLayout.tsx
@@ -2,15 +2,13 @@
 import React from 'react';
 import Navigation from './Navigation';
 import Footer from './Footer';
-import { useAppContext } from '../contexts/AppContext';
 
 export default function PageLayout({ children }: { children: React.ReactNode }) {
-  const { lang, setLang } = useAppContext();
   return (
     <main className="min-h-screen bg-gray-50 dark:bg-zinc-800">
-      <Navigation lang={lang} setLang={setLang} />
+      <Navigation />
       {children}
-      <Footer lang={lang} />
+      <Footer />
     </main>
   );
 }

--- a/src/Components/PrayerPreview.tsx
+++ b/src/Components/PrayerPreview.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { translations } from '../constants/translations';
 import { eventNames } from '../constants/prayerData';
-import type { Lang } from '../hooks/useLanguage';
 import { BellAlertIcon, ClockIcon } from '@heroicons/react/24/outline';
+import { useAppContext } from '../contexts/AppContext';
 
 interface PrayerPreviewProps {
-  lang: Lang;
   loadingNext: boolean;
   nextPrayer: { name: string; time: number } | null;
   todayTimings: Record<string, string> | null;
 }
 
-export default function PrayerPreview({ lang, loadingNext, nextPrayer, todayTimings }: PrayerPreviewProps) {
+export default function PrayerPreview({ loadingNext, nextPrayer, todayTimings }: PrayerPreviewProps) {
+  const { lang } = useAppContext();
   const formatDiff = (ms: number) => {
     const diff = Math.max(0, ms);
     const totalSeconds = Math.floor(diff / 1000);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ import { eventNames, alarmOptionsData } from '../constants/prayerData';
 import { LinkIcon } from '@heroicons/react/24/outline';
 
 export default function HomePage() {
-  const { lang, setLang, locationFields } = useAppContext();
+  const { lang, locationFields } = useAppContext();
 
   /* ---------- other form state ---------- */
   const [method, setMethod] = React.useState('5');
@@ -82,11 +82,10 @@ export default function HomePage() {
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-6 lg:col-span-2">
             {/* Location Inputs */}
-            <LocationInputs lang={lang} {...locationFields} />
+            <LocationInputs />
 
             {/* Method and Settings */}
             <MethodAndSettings
-              lang={lang}
               method={method}
               setMethod={setMethod}
               duration={duration}
@@ -97,7 +96,6 @@ export default function HomePage() {
 
             {/* Advanced Options */}
             <AdvancedOptions
-              lang={lang}
               showAdvanced={showAdvanced}
               setShowAdvanced={setShowAdvanced}
               alarms={alarms}
@@ -119,13 +117,13 @@ export default function HomePage() {
 
           <div className="space-y-6">
             {/* Prayer Preview */}
-            <PrayerPreview lang={lang} loadingNext={loadingNext} nextPrayer={nextPrayer} todayTimings={todayTimings} />
+            <PrayerPreview loadingNext={loadingNext} nextPrayer={nextPrayer} todayTimings={todayTimings} />
           </div>
         </div>
 
         {/* Instructions */}
         <div className="mt-10">
-          <InstructionsSection lang={lang} />
+          <InstructionsSection />
         </div>
       </div>
     </PageLayout>

--- a/src/app/pwa/page.tsx
+++ b/src/app/pwa/page.tsx
@@ -9,7 +9,7 @@ import { useTimingsPreview } from '../../hooks';
 import { translations } from '../../constants/translations';
 
 export default function PrayApp() {
-  const { lang, setLang, locationFields } = useAppContext();
+  const { lang, locationFields } = useAppContext();
   const [collapsed, setCollapsed] = React.useState(false);
   const [method, setMethod] = React.useState('5');
 
@@ -43,8 +43,8 @@ export default function PrayApp() {
       <div className="mx-auto max-w-screen-sm space-y-6 px-4 py-8">
         {!collapsed && (
           <div className="space-y-4">
-            <LocationInputs lang={lang} {...locationFields} />
-            <MethodSelect lang={lang} method={method} setMethod={setMethod} />
+            <LocationInputs />
+            <MethodSelect method={method} setMethod={setMethod} />
             <button
               type="button"
               onClick={handleSave}
@@ -65,8 +65,8 @@ export default function PrayApp() {
             </button>
           </div>
         )}
-        {collapsed && <MethodSelect lang={lang} method={method} setMethod={setMethod} />}
-        <PrayerPreview lang={lang} loadingNext={loadingNext} nextPrayer={nextPrayer} todayTimings={todayTimings} />
+        {collapsed && <MethodSelect method={method} setMethod={setMethod} />}
+        <PrayerPreview loadingNext={loadingNext} nextPrayer={nextPrayer} todayTimings={todayTimings} />
       </div>
     </PageLayout>
   );


### PR DESCRIPTION
## Summary
- refactor components to read app context directly instead of passing it via props
- update pages to use new component APIs
- keep TypeScript checks and tests passing

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm test`
- `npx prettier -c "src/**/*.{ts,tsx}"`