### PR TITLE
Fix dark mode opacity in InstallPrompt

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pray-calendar-v1';
+const CACHE_NAME = 'pray-calendar-v2';
 const STATIC_ASSETS = ['/', '/pwa', '/favicon.ico'];
 
 self.addEventListener('install', (event) => {

--- a/src/Components/InstallPrompt.tsx
+++ b/src/Components/InstallPrompt.tsx
@@ -23,7 +23,7 @@ export default function InstallPrompt() {
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-20 flex justify-center p-4">
-      <div className="max-w-screen-sm flex-1 rounded-lg bg-sky-50 p-4 shadow-lg dark:bg-sky-900/20">
+      <div className="max-w-screen-sm flex-1 rounded-lg bg-sky-50 p-4 shadow-lg dark:bg-sky-900/70">
         <div className="flex items-start justify-between gap-4">
           <div>
             <h3 className="mb-1 font-medium text-gray-900 dark:text-white">{translations[lang].installTitle}</h3>


### PR DESCRIPTION
## Summary
- update InstallPrompt dark mode background opacity for better readability
- bump service worker cache version

## Testing
- `pnpm test`
