### PR TITLE
Add API months validation

### DIFF
--- a/src/__tests__/app/api/prayer-times.ics/route.test.ts
+++ b/src/__tests__/app/api/prayer-times.ics/route.test.ts
@@ -188,6 +188,48 @@ describe('Prayer Times API', () => {
     );
   });
 
+  it('caps months parameter at 11', async () => {
+    const request = createMockRequest({
+      address: 'Cairo, Egypt',
+      method: '5',
+      months: '20',
+    });
+
+    await GET(request);
+
+    expect(getPrayerTimes).toHaveBeenCalledWith(
+      expect.any(Object),
+      11,
+      expect.objectContaining({
+        address: 'Cairo, Egypt',
+        method: '5',
+        months: '11',
+        lang: 'en',
+      }),
+    );
+  });
+
+  it('floors months parameter to 1', async () => {
+    const request = createMockRequest({
+      address: 'Cairo, Egypt',
+      method: '5',
+      months: '0',
+    });
+
+    await GET(request);
+
+    expect(getPrayerTimes).toHaveBeenCalledWith(
+      expect.any(Object),
+      1,
+      expect.objectContaining({
+        address: 'Cairo, Egypt',
+        method: '5',
+        months: '1',
+        lang: 'en',
+      }),
+    );
+  });
+
   it('respects duration parameter', async () => {
     const request = createMockRequest({
       address: 'Cairo, Egypt',

--- a/src/app/api/prayer-times.ics/route.ts
+++ b/src/app/api/prayer-times.ics/route.ts
@@ -61,6 +61,16 @@ export async function GET(request: NextRequest) {
   // Ensure lang has a value for cache key consistency
   allRequestParams.lang = lang;
 
+  // Sanitize months parameter
+  let monthsCount = 3;
+  if (months !== null) {
+    const parsed = parseInt(months, 10);
+    if (!isNaN(parsed)) {
+      monthsCount = Math.min(Math.max(parsed, 1), 11);
+    }
+    allRequestParams.months = monthsCount.toString();
+  }
+
   // Build query params object for getPrayerTimes (excluding UI-specific params)
   const queryParams: any = {};
   for (const [key, value] of searchParams.entries()) {
@@ -77,7 +87,7 @@ export async function GET(request: NextRequest) {
   try {
     // Fetch calendar data – now accepts address OR latitude/longitude
     // Pass all request parameters for comprehensive cache key generation
-    const days = await getPrayerTimes(queryParams, months ? +months : 3, allRequestParams);
+    const days = await getPrayerTimes(queryParams, monthsCount, allRequestParams);
     if (!days) {
       return NextResponse.json({ message: 'Invalid address or coordinates' }, { status: 400 });
     }


### PR DESCRIPTION
## Summary
- clamp `months` query param between 1 and 11 in `/api/prayer-times.ics`
- unit tests for new months validation logic

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ecaac196c8328ada8b39bf824d169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the months query parameter in the Prayer Times API to ensure values are always within the valid range (1 to 11), preventing invalid input from affecting results.

- **Tests**
  - Added tests to verify correct clamping of the months parameter to its allowed range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->