### PR TITLE
Remove caching logs

### DIFF
--- a/scripts/generate-sw.js
+++ b/scripts/generate-sw.js
@@ -12,4 +12,3 @@ let content = fs.readFileSync(templatePath, 'utf8');
 content = content.replace('__CACHE_VERSION__', cacheVersion);
 
 fs.writeFileSync(outputPath, content);
-console.log(`Generated service worker with cache version: ${cacheVersion}`);

--- a/src/app/api/prayer-times.ics/route.ts
+++ b/src/app/api/prayer-times.ics/route.ts
@@ -153,14 +153,6 @@ export async function GET(request: NextRequest) {
       ', ',
     );
 
-    console.log('Generated prayer times calendar:', {
-      location: queryParams.address || `${queryParams.latitude},${queryParams.longitude}`,
-      events: allowedEvents.length,
-      days: days.length,
-      cacheTag,
-      cacheControl,
-    });
-
     return new NextResponse(calendar.toString(), {
       headers: {
         'Content-Type': 'text/calendar; charset=utf-8',

--- a/src/hooks/useTimingsPreview.ts
+++ b/src/hooks/useTimingsPreview.ts
@@ -51,7 +51,6 @@ export function useTimingsPreview(deps: UseTimingsPreviewDeps) {
     const cachedEntry = previewCache.get(cacheKey);
 
     if (cachedEntry && isPreviewCacheValid(cachedEntry)) {
-      console.log('Using cached preview data:', cacheKey);
       setTodayTimings(cachedEntry.data.timings);
       setNextPrayer(cachedEntry.data.nextPrayer);
       return;
@@ -64,7 +63,6 @@ export function useTimingsPreview(deps: UseTimingsPreviewDeps) {
           ? `https://api.aladhan.com/v1/timingsByAddress?address=${encodeURIComponent(address)}&method=${method}`
           : `https://api.aladhan.com/v1/timings?latitude=${latitude}&longitude=${longitude}&method=${method}`;
 
-      console.log('Fetching fresh preview data:', cacheKey);
       const j = await (await fetch(url)).json();
       if (j.code !== 200) throw new Error();
 

--- a/src/prayerTimes.ts
+++ b/src/prayerTimes.ts
@@ -239,16 +239,7 @@ export async function getPrayerTimes(
   const cachedEntry = prayerTimesCache.get(cacheKey);
   if (cachedEntry && isCacheValid(cachedEntry)) {
     cacheMonitor.recordHit();
-    console.log('Cache hit for prayer times:', {
-      cacheKey: cacheKey.substring(0, 100) + '...',
-      age: Date.now() - cachedEntry.timestamp,
-      cacheSize: estimateCacheSize(prayerTimesCache),
-    });
     return cachedEntry.data;
-  }
-
-  if (cachedEntry) {
-    console.log('Cache entry found but invalid, fetching fresh data');
   }
 
   /* ----------------------------- range build ----------------------- */
@@ -265,12 +256,6 @@ export async function getPrayerTimes(
   /* ----------------------------- fetch with Next.js cache --------- */
   try {
     cacheMonitor.recordMiss();
-    console.log('Cache miss, fetching from AlAdhan API:', {
-      cacheKey: cacheKey.substring(0, 100) + '...',
-      url: baseUrl,
-      cacheSize: estimateCacheSize(prayerTimesCache),
-      cacheStats: cacheMonitor.getStats(),
-    });
 
     // Use Next.js fetch with built-in caching instead of axios
     const url = new URL(baseUrl);
@@ -309,19 +294,12 @@ export async function getPrayerTimes(
       });
     }
 
-    console.log('Successfully cached prayer times:', {
-      cacheKey: cacheKey.substring(0, 100) + '...',
-      dataPoints: data.data.length,
-      timezone,
-      newCacheSize: estimateCacheSize(prayerTimesCache),
-    });
-
     // Periodic cache health check
     if (Math.random() < 0.05) {
       // 5% chance
       const health = checkCacheHealth(prayerTimesCache);
       if (!health.isHealthy) {
-        console.warn('Cache health issues detected:', health);
+        // handle cache health issues silently
       }
     }
 
@@ -332,7 +310,6 @@ export async function getPrayerTimes(
 
     // Fallback: return stale cache if available
     if (cachedEntry) {
-      console.log('Returning stale cache due to fetch error');
       return cachedEntry.data;
     }
   }

--- a/src/utils/cacheUtils.ts
+++ b/src/utils/cacheUtils.ts
@@ -57,13 +57,6 @@ class CacheMonitor {
       lastReset: Date.now(),
     };
   }
-
-  logStats() {
-    console.log('Cache Statistics:', {
-      ...this.stats,
-      uptime: `${Math.round((Date.now() - this.stats.lastReset) / 1000 / 60)} minutes`,
-    });
-  }
 }
 
 // Global cache monitor instance


### PR DESCRIPTION
## Summary
- clean up console logging related to cache usage
- remove unused logStats method

## Testing
- `npm test`
- `npx prettier -w scripts/generate-sw.js src/hooks/useTimingsPreview.ts src/app/api/prayer-times.ics/route.ts src/prayerTimes.ts src/utils/cacheUtils.ts`

------
https://chatgpt.com/codex/tasks/task_e_684ecaf4699883288f166364f3f5ab3b